### PR TITLE
Install boost in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -qqy --no-install-recommends \
     git \
     python-is-python3 \
     ninja-build \
+    libboost-all-dev \
     build-essential \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Install libboost-all-dev using apt-get install.

Needed to run `./gradlew jvmTest` in [Wally Wallet](https://gitlab.com/wallywallet/wallet) CI based from this image